### PR TITLE
base/arch-desktop: fix lightdm config

### DIFF
--- a/base/arch-desktop/_init
+++ b/base/arch-desktop/_init
@@ -17,7 +17,7 @@ install() {
     xorg-server xorg-xrandr xorg-xinit xorg-xlsfonts xorg-xfd xdotool \
     lightdm lightdm-mini-greeter \
     bspwm sxhkd compton dunst xcb-proto polybar libnotify \
-    rvxt-unicode rvxt-unicode-terminfo \
+    rxvt-unicode rxvt-unicode-terminfo \
     slop feh maim ffmpeg zbar \
     keybase-bin pass pass-otp \
     neofetch glances inxi dfc youtube-dl \

--- a/base/arch-desktop/_init
+++ b/base/arch-desktop/_init
@@ -36,14 +36,14 @@ install() {
   # set up lightdm + minigreeter
   sudo systemctl enable lightdm
   sudo sed -i \
-    -e "s@^#?\(greeter-session=\).+@\1lightdm-mini-greeter@" \
-    -e "s@^#?\(user-session=\).+@\1bspwm@" \
-    /etc/lightdm/lightdm.conf
+      -e "s@^#\?\(greeter-session=\).\+@\1lightdm-mini-greeter@" \
+      -e "s@^#\?\(user-session=\).\+@\1bspwm@" \
+      /etc/lightdm/lightdm.conf
   sudo sed -i \
-    -e "s@^\(user = \).+@\1${USER}@" \
-    -e "s@^\(show-password-label = \).+@\1false@" \
-    -e "s@^\(background-color = \).+@\1\"#000000\"@;" \
-    /etc/lightdm/lightdm-mini-greeter.conf
+      -e "s@^\(user = \).\+@\1${USER}@" \
+      -e "s@^\(show-password-label = \).\+@\1false@" \
+      -e "s@^\(background-color = \).\+@\1\"#000000\"@;" \
+      /etc/lightdm/lightdm-mini-greeter.conf
 }
 
 # update() {}


### PR DESCRIPTION
the `sed ` commands didn't work on the config files, it seems that `?` and `+` needs to be converted to  `\?` and `\+`. 