### PR TITLE
Bluetooth: Change deprecated parameter extraConfig to config

### DIFF
--- a/modules/hardware/bluetooth.nix
+++ b/modules/hardware/bluetooth.nix
@@ -22,11 +22,10 @@ in {
         # Enable additional codecs
         extraModules = [ pkgs.pulseaudio-modules-bt ];
       };
-
-      hardware.bluetooth.extraConfig = ''
-        [General]
-        Enable=Source,Sink,Media,Socket
-      '';
+      
+      hardware.bluetooth.config = {
+        General = { Enable = "Source,Sink,Media,Socket"; };
+      };
     })
   ]);
 }


### PR DESCRIPTION
The parameter `hardware.bluetooth.extraConfig` is deprecated.

Changing to `hardware.bluetooth.config` parameter.