### PR TITLE
Replace deprecated configuration options for dunst

### DIFF
--- a/modules/themes/alucard/config/dunstrc
+++ b/modules/themes/alucard/config/dunstrc
@@ -2,7 +2,6 @@
 ''
 [global]
 alignment = left
-bounce_freq = 0
 browser = firefox -new-tab
 corner_radius = 2
 dmenu = rofi -dmenu -p dunst:
@@ -11,8 +10,10 @@ font = ${fonts.sans.name} ${toString(fonts.sans.size)}
 format = "<b>%s</b>\n%b"
 frame_color = "${colors.types.border}"
 frame_width = 1
-# geometry [{width}]x{height}][+/-{x}+/-{y}]
-geometry = "440x15-26+26"
+origin = top-right
+width = 440
+height = 15
+offset = -26, +26
 history_length = 20
 horizontal_padding = 16
 icon_position = right
@@ -30,7 +31,6 @@ show_age_threshold = 60
 show_indicators = yes
 shrink = no
 sort = yes
-startup_notification = false
 sticky_history = yes
 transparency = 5
 word_wrap = yes


### PR DESCRIPTION
I based my NixOS config on yours and forked it a while ago so it certainly looks a lot different now.
Thanks for leading me into this wonderful rabbit hole :rabbit2: 

I noticed that the dunst config still uses a couple of deprecated options which no longer work with newer versions.

```
WARNING: Setting bounce_freq in section global doesn't exist
WARNING: Setting geometry in section global doesn't exist
WARNING: Setting startup_notification in section global doesn't exist
```

Usage information of the new options can be found [here](https://github.com/dunst-project/dunst/blob/master/docs/dunst.5.pod)